### PR TITLE
Add twitter card meta.

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,12 @@
         <meta property="og:title" content="Critical Mass Hamburg" />
         <meta property="og:description" content="Die Critical Mass Hamburg ist jeden letzten Freitag im Monat mit einer Radtour in Hamburg unterwegs." />
         <meta property="og:image" content="https://criticalmass.hamburg/img/opengraph/preview.jpg" />
+
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:site" content="@cm_hh" />
+        <meta name="twitter:title" content="Critical Mass Hamburg" />
+        <meta name="twitter:description" content="Die Critical Mass Hamburg ist jeden letzten Freitag im Monat mit einer Radtour in Hamburg unterwegs." />
+        <meta name="twitter:image" content="https://criticalmass.hamburg/img/opengraph/preview.jpg" />
     </head>
     <body>
         <a href="https://github.com/maltehuebner/criticalmass-hamburg">


### PR DESCRIPTION
As sharing is also done at twitter links to criticalmass.hamburg should appear with a nice image and description.