### PR TITLE
Add link to GitHub to help understand pull requests

### DIFF
--- a/index.html
+++ b/index.html
@@ -200,6 +200,10 @@
                                 <i class="fa fa-github" aria-hidden="true"></i>
                                 GitHub
                             </a>
+
+                            <a href="https://help.github.com/articles/about-pull-requests/" class="btn btn-secondary">
+                                <i class="fa fa-question" aria-hidden="true"></i>
+                            </a>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
I guess, contributing to criticalmass.hamburg will be hard for most Radlings as they do not understand GitHub. I added a link to GitHub help but I am not sure that it will really help people to contribute. Are there any better manuals? Something like "GitHub in three minutes"?